### PR TITLE
Fix missing first character of package name

### DIFF
--- a/NuGetCleaner/Program.cs
+++ b/NuGetCleaner/Program.cs
@@ -118,7 +118,7 @@ namespace NuGetCleaner
 
                         if (dirAge.TotalDays >= Days)
                         {
-                            Console.WriteLine(pkgVersion.Substring(Path.Length + 1) + " --- Last Access: " + RecursiveFindLAT(pkgVersion, DateTime.MinValue));
+                            Console.WriteLine(pkgVersion.Substring(Path.Length) + " --- Last Access: " + RecursiveFindLAT(pkgVersion, DateTime.MinValue));
                         }
                     }
                 }


### PR DESCRIPTION
When using `nugetcleaner --dry-run --days N` the first character of package names removed by `pkgVersion.Substring(Path.Length + 1)`. It should be `pkgVersion.Substring(Path.Length)` without the `+1`.

Before:
```
syncio\0.1.26 --- Last Access: 5/12/2022 11:19:41 AM
```

After
```
asyncio\0.1.26 --- Last Access: 5/12/2022 11:19:41 AM
```

Mentioned here: #3 